### PR TITLE
Test/audit management

### DIFF
--- a/src/main/kotlin/data/repositories/AuditRepositoryImpl.kt
+++ b/src/main/kotlin/data/repositories/AuditRepositoryImpl.kt
@@ -1,5 +1,21 @@
 package data.repositories
 
+import logic.models.AuditLog
 import logic.repositoies.AuditRepository
+import java.io.File
+import java.util.*
 
-class AuditRepositoryImpl : AuditRepository
+class AuditRepositoryImpl(private val csvFile: File) : AuditRepository {
+
+    override fun add(log: AuditLog?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllByTaskId(taskId: UUID): List<AuditLog> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllByProjectId(projectId: UUID): List<AuditLog> {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/logic/repositoies/AuditRepository.kt
+++ b/src/main/kotlin/logic/repositoies/AuditRepository.kt
@@ -1,4 +1,10 @@
 package logic.repositoies
 
+import logic.models.AuditLog
+import java.util.*
+
 interface AuditRepository {
+    fun add(log: AuditLog?): Boolean
+    fun getAllByTaskId(taskId: UUID): List<AuditLog>
+    fun getAllByProjectId(projectId: UUID): List<AuditLog>
 }

--- a/src/main/kotlin/logic/usecases/audit/AddAuditLogUseCase.kt
+++ b/src/main/kotlin/logic/usecases/audit/AddAuditLogUseCase.kt
@@ -1,0 +1,10 @@
+package logic.usecases.audit
+
+import logic.models.AuditLog
+import logic.repositoies.AuditRepository
+
+class AddAuditLogUseCase (private val auditLogRepository : AuditRepository){
+    fun invoke(log: AuditLog?): Boolean {
+        return auditLogRepository.add(log)
+    }
+}

--- a/src/main/kotlin/logic/usecases/audit/ViewAuditLogsByProjectUseCase.kt
+++ b/src/main/kotlin/logic/usecases/audit/ViewAuditLogsByProjectUseCase.kt
@@ -1,0 +1,11 @@
+package logic.usecases.audit
+
+import logic.models.AuditLog
+import logic.repositoies.AuditRepository
+import java.util.UUID
+
+class ViewAuditLogsByProjectUseCase(private val auditLogUseCase: AuditRepository) {
+    operator fun invoke(projectId: UUID): List<AuditLog>{
+        return auditLogUseCase.getAllByProjectId(projectId)
+    }
+}

--- a/src/main/kotlin/logic/usecases/audit/ViewAuditLogsByTaskUseCase.kt
+++ b/src/main/kotlin/logic/usecases/audit/ViewAuditLogsByTaskUseCase.kt
@@ -1,0 +1,11 @@
+package logic.usecases.audit
+
+import logic.models.AuditLog
+import logic.repositoies.AuditRepository
+import java.util.UUID
+
+class ViewAuditLogsByTaskUseCase(private val auditLogUseCase: AuditRepository) {
+    operator fun invoke(taskId: UUID):  List<AuditLog>{
+        return auditLogUseCase.getAllByTaskId(taskId)
+    }
+}

--- a/src/test/kotlin/logic/usecases/audit/AddAuditLogUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecases/audit/AddAuditLogUseCaseTest.kt
@@ -1,0 +1,150 @@
+package logic.usecases.audit
+
+import logic.models.AuditLog
+import logic.models.AuditType
+import data.repositories.AuditRepositoryImpl
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import kotlinx.datetime.LocalDateTime
+import logic.repositoies.AuditRepository
+import java.io.File
+import java.util.UUID
+
+ class AddAuditLogUseCaseTest {
+  private lateinit var testFile: File
+  private lateinit var repository: AuditRepositoryImpl
+
+  @BeforeEach
+  fun setUp() {
+   testFile = File.createTempFile("test-audit", ".csv")
+   repository = AuditRepositoryImpl(testFile)
+  }
+
+  @AfterEach
+  fun tearDown() {
+   testFile.delete()
+  }
+
+  @Test
+  fun `add should append log to file and return true`() {
+   val repository = mockk<AuditRepository>()
+
+   every { repository.add(any()) } returns true
+
+   val log = AuditLog(
+    id = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+    auditType = AuditType.TASK,
+    action = "Task created",
+    timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+    entityId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
+    userId = UUID.fromString("00000000-0000-0000-0000-000000000003")
+   )
+   val result = repository.add(log)
+
+   assertTrue(result)
+   verify { repository.add(log) }
+  }
+
+  @Test
+  fun `getAllByTaskId should return only task logs for given taskId`() {
+   val repository = mockk<AuditRepository>()
+
+   // Test data
+   val taskId = UUID.fromString("00000000-0000-0000-0000-000000000004")
+   val userId = UUID.fromString("00000000-0000-0000-0000-000000000005")
+
+   val log = AuditLog(
+    id = UUID.fromString("00000000-0000-0000-0000-000000000006"),
+    auditType = AuditType.TASK,
+    action = "Task created",
+    timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+    entityId = taskId,
+    userId = userId
+   )
+
+   every { repository.getAllByTaskId(taskId) } returns listOf(log)
+
+   // Verify
+   val result = repository.getAllByTaskId(taskId)
+   assertEquals(1, result.size)
+   assertEquals(log.id, result[0].id)
+  }
+
+  @Test
+  fun `getAllByProjectId should return only project logs for given projectId`() {
+   val repository = mockk<AuditRepository>()
+
+   val projectId = UUID.fromString("00000000-0000-0000-0000-000000000007")
+   val userId = UUID.fromString("00000000-0000-0000-0000-000000000008")
+
+   val log = AuditLog(
+    id = UUID.fromString("00000000-0000-0000-0000-000000000009"),
+    auditType = AuditType.PROJECT,
+    action = "Project created",
+    timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+    entityId = projectId,
+    userId = userId
+   )
+
+   every { repository.getAllByProjectId(projectId) } returns listOf(log)
+
+   val result = repository.getAllByProjectId(projectId)
+   assertEquals(1, result.size)
+   assertEquals(log.id, result[0].id)
+  }
+
+  @Test
+  fun `invoke should return true when audit log is successfully added`() {
+   val mockRepository = mockk<AuditRepository>()
+   every { mockRepository.add(any()) } returns true
+
+   val useCase = AddAuditLogUseCase(mockRepository)
+   val testLog = AuditLog(
+    id = UUID.fromString("00000000-0000-0000-0000-000000000010"),
+    auditType = AuditType.TASK,
+    action = "Test Action",
+    timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+    entityId = UUID.fromString("00000000-0000-0000-0000-000000000011"),
+    userId = UUID.fromString("00000000-0000-0000-0000-000000000012")
+   )
+
+   val result = useCase.invoke(testLog)
+   assertTrue(result)
+   verify { mockRepository.add(any()) }
+  }
+
+  @Test
+  fun `invoke should return false when repository fails to add audit log`() {
+   val mockRepository = mockk<AuditRepository>()
+   every { mockRepository.add(any()) } returns false
+
+   val useCase = AddAuditLogUseCase(mockRepository)
+   val testLog = AuditLog(id = UUID.fromString("00000000-0000-0000-0000-000000000013"),
+    auditType = AuditType.TASK,
+    action = "Test Action",
+    timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+    entityId = UUID.fromString("00000000-0000-0000-0000-000000000014"),
+    userId = UUID.fromString("00000000-0000-0000-0000-000000000015")
+   )
+
+   val result = useCase.invoke(testLog)
+
+   assertFalse(result)
+   verify { mockRepository.add(testLog) }
+  }
+
+  @Test
+  fun `invoke should return false when audit log is invalid`() {
+   val mockRepository = mockk<AuditRepository>()
+   every { mockRepository.add(any()) } returns false
+
+   val useCase = AddAuditLogUseCase(mockRepository)
+
+   assertFalse(useCase.invoke(null))
+  }
+ }

--- a/src/test/kotlin/logic/usecases/audit/ViewAuditLogsByProjectUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecases/audit/ViewAuditLogsByProjectUseCaseTest.kt
@@ -1,0 +1,134 @@
+package logic.usecases.audit
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import logic.models.AuditLog
+import logic.models.AuditType
+import logic.repositoies.AuditRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlinx.datetime.LocalDateTime
+import java.util.*
+
+ class ViewAuditLogsByProjectUseCaseTest{
+  private lateinit var repository: AuditRepository
+  private lateinit var useCase: ViewAuditLogsByProjectUseCase
+
+  @BeforeEach
+  fun setUp() {
+   repository = mockk()
+   useCase = ViewAuditLogsByProjectUseCase(repository)
+  }
+
+  @Test
+  fun `invoke should return empty list when no logs exist for project`() {
+   // Given
+   val projectId = UUID.randomUUID()
+   every { repository.getAllByProjectId(projectId) } returns emptyList()
+
+   // When
+   val result = useCase(projectId)
+
+   // Then
+   assertTrue(result.isEmpty())
+   verify(exactly = 1) { repository.getAllByProjectId(projectId) }
+  }
+
+  @Test
+  fun `invoke should return only project logs for given project ID`() {
+   // Given
+   val projectId = UUID.fromString("00000000-0000-0000-0000-000000000020")
+   val expectedLogs = listOf(
+    AuditLog(
+     id = UUID.fromString("00000000-0000-0000-0000-000000000020"),
+     auditType = AuditType.PROJECT,
+     action = "Project created",
+     timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+     entityId = projectId,
+     userId = UUID.fromString("00000000-0000-0000-0000-000000000020")
+    )
+   )
+
+   every { repository.getAllByProjectId(projectId) } returns expectedLogs
+
+   // When
+   val result = useCase(projectId)
+
+   // Then
+   assertEquals(expectedLogs.size, result.size)
+   assertEquals(projectId, result[0].entityId)
+   assertEquals(AuditType.PROJECT, result[0].auditType)
+   verify(exactly = 1) { repository.getAllByProjectId(projectId) }
+  }
+
+  @Test
+  fun `invoke should not return task logs for given project ID`() {
+   // Given
+   val projectId = UUID.fromString("00000000-0000-0000-0000-000000000020")
+   val taskId = UUID.fromString("00000000-0000-0000-0000-000000000020")
+   val mixedLogs = listOf(
+    AuditLog(
+     id = UUID.fromString("00000000-0000-0000-0000-000000000020"),
+     auditType = AuditType.PROJECT,
+     action = "Project updated",
+     timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+     entityId = projectId,
+     userId = UUID.fromString("00000000-0000-0000-0000-000000000020")
+    ),
+    AuditLog(
+     id = UUID.fromString("00000000-0000-0000-0000-000000000020"),
+     auditType = AuditType.TASK,
+     action = "Task created",
+     timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+     entityId = taskId,
+     userId = UUID.fromString("00000000-0000-0000-0000-000000000020")
+    )
+   )
+
+   every { repository.getAllByProjectId(projectId) } returns mixedLogs.filter { it.auditType == AuditType.PROJECT && it.entityId == projectId }
+
+   // When
+   val result = useCase(projectId)
+
+   // Then
+   assertEquals(1, result.size)
+   assertEquals(AuditType.PROJECT, result[0].auditType)
+   verify(exactly = 1) { repository.getAllByProjectId(projectId) }
+  }
+
+  @Test
+  fun `invoke should return multiple logs when multiple project logs exist`() {
+   // Given
+   val projectId = UUID.fromString("00000000-0000-0000-0000-000000000020")
+   val expectedLogs = listOf(
+    AuditLog(
+     id = UUID.fromString("00000000-0000-0000-0000-000000000020"),
+     auditType = AuditType.PROJECT,
+     action = "Project created",
+     timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+     entityId = projectId,
+     userId = UUID.fromString("00000000-0000-0000-0000-000000000020")
+    ),
+    AuditLog(
+     id = UUID.fromString("00000000-0000-0000-0000-000000000020"),
+     auditType = AuditType.PROJECT,
+     action = "Project updated",
+     timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+     entityId = projectId,
+     userId = UUID.fromString("00000000-0000-0000-0000-000000000020")
+    )
+   )
+
+   every { repository.getAllByProjectId(projectId) } returns expectedLogs
+
+   // When
+   val result = useCase(projectId)
+
+   // Then
+   assertEquals(2, result.size)
+   assertTrue(result.all { it.auditType == AuditType.PROJECT && it.entityId == projectId })
+   verify(exactly = 1) { repository.getAllByProjectId(projectId) }
+  }
+ }

--- a/src/test/kotlin/logic/usecases/audit/ViewAuditLogsByTaskUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecases/audit/ViewAuditLogsByTaskUseCaseTest.kt
@@ -1,0 +1,100 @@
+package logic.usecases.audit
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import logic.models.AuditLog
+import logic.models.AuditType
+import logic.repositoies.AuditRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import kotlinx.datetime.LocalDateTime
+import java.util.UUID
+
+ class ViewAuditLogsByTaskUseCaseTest{
+  private  lateinit var repository: AuditRepository
+  private lateinit var useCase: ViewAuditLogsByTaskUseCase
+  @BeforeEach
+  fun setUp() {
+   repository = mockk()
+   useCase = ViewAuditLogsByTaskUseCase(repository)
+  }
+
+  @Test
+  fun `invoke should return empty list when no logs exist for task`() {
+   // Given
+   val taskId = UUID.fromString("00000000-0000-0000-0000-000000000020")
+   every { repository.getAllByTaskId(taskId) } returns emptyList()
+
+   // When
+   val result = useCase(taskId)
+
+   // Then
+   assertTrue(result.isEmpty())
+   verify(exactly = 1) { repository.getAllByTaskId(taskId) }
+  }
+
+  @Test
+  fun `invoke should return only task logs for given task ID`() {
+   // Given
+   val taskId = UUID.fromString("00000000-0000-0000-0000-000000000021")
+   val expectedLogs = listOf(
+    AuditLog(
+     id = UUID.fromString("00000000-0000-0000-0000-000000000022"),
+     auditType = AuditType.TASK,
+     action = "Task created",
+     timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+     entityId = taskId,
+     userId = UUID.fromString("00000000-0000-0000-0000-000000000023")
+    )
+   )
+
+   every { repository.getAllByTaskId(taskId) } returns expectedLogs
+
+   // When
+   val result = useCase(taskId)
+
+   // Then
+   assertEquals(expectedLogs.size, result.size)
+   assertEquals(taskId, result[0].entityId)
+   assertEquals(AuditType.TASK, result[0].auditType)
+   verify(exactly = 1) { repository.getAllByTaskId(taskId) }
+  }
+
+  @Test
+  fun `invoke should not return project logs for given task ID`() {
+   // Given
+   val taskId = UUID.fromString("00000000-0000-0000-0000-000000000024")
+   val projectId = UUID.fromString("00000000-0000-0000-0000-000000000025")
+   val mixedLogs = listOf(
+    AuditLog(
+     id = UUID.fromString("00000000-0000-0000-0000-000000000026"),
+     auditType = AuditType.TASK,
+     action = "Task created",
+     timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+     entityId = taskId,
+     userId = UUID.fromString("00000000-0000-0000-0000-000000000027")
+    ),
+    AuditLog(
+     id = UUID.fromString("00000000-0000-0000-0000-000000000028"),
+     auditType = AuditType.PROJECT,
+     action = "Project updated",
+     timestamp = LocalDateTime(2023, 12, 31, 23, 59, 59),
+     entityId = projectId,
+     userId = UUID.fromString("00000000-0000-0000-0000-000000000029")
+    )
+   )
+
+   every { repository.getAllByTaskId(taskId) } returns mixedLogs.filter { it.auditType == AuditType.TASK && it.entityId == taskId }
+
+   // When
+   val result = useCase(taskId)
+
+   // Then
+   assertEquals(1, result.size)
+   assertEquals(AuditType.TASK, result[0].auditType)
+   verify(exactly = 1) { repository.getAllByTaskId(taskId) }
+  }
+
+ }


### PR DESCRIPTION
Add tests for audit management use cases:

**Use Cases: **
> AddAuditLogUseCase
> ViewAuditLogsByProjectUseCase
> ViewAuditLogsByTaskUseCase


**audit_logs.csv Fields: **
id: UUID, auditType: AuditType (Project - Task) , action: String, timestamp: LocalDateTime, entityId: UUID, userId: UUID

**AuditLogRepository: **
`add(log: AuditLog): Boolean` -> `AddAuditLogUseCase`
`getAllByTaskId(taskId: UUID): List` -> `ViewAuditLogsByTaskUseCase`
`getAllByProjectId(projectId: UUID): List `-> ViewAuditLogsByProjectUseCase